### PR TITLE
Fix: request smuggling FP when sending email

### DIFF
--- a/plugins/roundcube-rule-exclusions-before.conf
+++ b/plugins/roundcube-rule-exclusions-before.conf
@@ -41,16 +41,23 @@ SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:_curpasswd,\
     ver:'roundcube-rule-exclusions-plugin/1.0.0'"
 
-# When composing an email
+# When sending an email
 SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
     "id:9519103,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=942131;ARGS:_to,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:_message,\
-    ver:'roundcube-rule-exclusions-plugin/1.0.0'"
+    ver:'roundcube-rule-exclusions-plugin/1.0.0',\
+    chain"
+    SecRule ARGS:_task "@streq mail" \
+        "t:none,\
+        chain"
+        SecRule ARGS:_action "@streq send" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+            ctl:ruleRemoveTargetById=942131;ARGS:_to,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:_message"
 
 # When creating/modifying/searching contacts
 SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
@@ -76,7 +83,6 @@ SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
     ver:'roundcube-rule-exclusions-plugin/1.0.0'"
 
 # When creating/modifying sieve filters
-# Modifying raw code for sieve filters
 SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
     "id:9519106,\
     phase:1,\


### PR DESCRIPTION
Resolves false positive when sending an email with a word like get and a line break.

Closes https://github.com/EsadCetiner/roundcube-rule-exclusions-plugin/issues/1