### PR TITLE
Fix: HTML editor FP

### DIFF
--- a/plugins/roundcube-rule-exclusions-before.conf
+++ b/plugins/roundcube-rule-exclusions-before.conf
@@ -1,6 +1,23 @@
 # Generic rule to disable plugin
 SecRule TX:roundcube-rule-exclusions-plugin "@eq 0" "id:9519010,phase:1,pass,nolog,ctl:ruleRemoveById=9519100-9519999"
 
+#
+# [ Local CRS initialization ]
+#
+# We need to initialize some of the CRS variables also here because plugin setup runs before
+# CRS initialization (this is a known limitation of the current plugin architecture). Must be
+# kept in sync with CRS default setting.
+
+# Copy of CRS rule 901162.
+SecRule &TX:allowed_request_content_type "@eq 0" \
+    "id:9519020,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'sogo-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
+
+
 # Since Roundcube does everything within the same URL path, this plugin tries to improve code readability by creating seperate rules based
 # upon what kind of false positives they fix.
 
@@ -42,6 +59,7 @@ SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
     ver:'roundcube-rule-exclusions-plugin/1.0.0'"
 
 # When sending an email
+# Composing an email in a new window
 SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
     "id:9519103,\
     phase:2,\
@@ -188,3 +206,20 @@ SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
     SecRule ARGS:_from "@streq set" \
         "t:none,\
         ctl:ruleRemoveTargetById=932236;ARGS:_from"
+
+# Composing an email in HTML mode
+# Creating a signature in HTML mode
+SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
+    "id:9519113,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'roundcube-rule-exclusions-plugin/1.0.0',\
+    chain"
+    SecRule ARGS:_task "@streq utils" \
+        "t:none,\
+        chain"
+        SecRule ARGS:_action "@rx ^(?:text2html|html2text)$" \
+            "t:none,\
+            setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |application/octet-stream|'"


### PR DESCRIPTION
Resolves false positives relating to using the HTML editor to compose emails or create email signatures

Closes https://github.com/EsadCetiner/roundcube-rule-exclusions-plugin/issues/3