### PR TITLE
fix: case sensitive content type and invalid rule id matches in tests

### DIFF
--- a/plugins/roundcube-rule-exclusions-before.conf
+++ b/plugins/roundcube-rule-exclusions-before.conf
@@ -62,13 +62,14 @@ SecRule REQUEST_FILENAME "@beginsWith %{tx.roundcube-rule-exclusions-path}" \
     chain"
     SecRule ARGS:_task "@streq login" \
         "t:none,\
+        ctl:ruleRemoveTargetById=920273;ARGS:_timezone,\
         ctl:ruleRemoveTargetById=920273;ARGS:_user,\
-        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:_action,\
-        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:_framed,\
-        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:_task,\
         ctl:ruleRemoveTargetById=932235;ARGS:_url,\
         ctl:ruleRemoveTargetById=932236;ARGS:_url,\
         ctl:ruleRemoveTargetById=942432;ARGS:_url,\
+        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:_action,\
+        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:_framed,\
+        ctl:ruleRemoveTargetById=921180;TX:paramcounter_ARGS_NAMES:_task,\
         ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:_pass"
 
 # Keywords like settings and mail frequently appear in the referrer header when doing pretty much anything

--- a/tests/regression/roundcube-rule-exclusions-plugin/9519101.yaml
+++ b/tests/regression/roundcube-rule-exclusions-plugin/9519101.yaml
@@ -24,7 +24,7 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: |
-              id "920273" | id "921180" | id "932235" | id "932236" | id "942432" | id "941110"
+              id "920273"|id "921180"|id "932235"|id "932236"|id "942432"|id "941110"
   - test_title: 9519101-2
     desc: Logging into roundcube
     stages:
@@ -44,4 +44,4 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: |
-              id "920273" | id "921180" | id "932235" | id "932236" | id "942432" | id "941110"
+              id "920273"|id "921180"|id "932235"|id "932236"|id "942432"|id "941110"

--- a/tests/regression/roundcube-rule-exclusions-plugin/9519102.yaml
+++ b/tests/regression/roundcube-rule-exclusions-plugin/9519102.yaml
@@ -22,7 +22,7 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: |
-              id "932237"| id "932239"
+              id "932237"|id "932239"
   - test_title: 9519102-2
     desc: Disable 932237 and 932239 for logout token in referer
     stages:
@@ -40,4 +40,4 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: |
-              id "932237"| id "932239"
+              id "932237"|id "932239"

--- a/tests/regression/roundcube-rule-exclusions-plugin/9519114.yaml
+++ b/tests/regression/roundcube-rule-exclusions-plugin/9519114.yaml
@@ -46,4 +46,4 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: |
-              id "(?:921180|941101|942131)"
+              id "921180"|id "941101"|id "942131"

--- a/tests/regression/roundcube-rule-exclusions-plugin/9519115.yaml
+++ b/tests/regression/roundcube-rule-exclusions-plugin/9519115.yaml
@@ -15,7 +15,7 @@ tests:
               Host: localhost
               User-Agent: Roundcube rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              content-type: application/octet-stream
+              Content-Type: application/octet-stream
             port: 80
             method: POST
             uri: /post?_task=utils&_action=text2html
@@ -32,7 +32,7 @@ tests:
               Host: localhost
               User-Agent: Roundcube rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              content-type: application/octet-stream
+              Content-Type: application/octet-stream
             port: 80
             method: POST
             uri: /post?_task=utils&_action=html2text

--- a/tests/regression/roundcube-rule-exclusions-plugin/9519153.yaml
+++ b/tests/regression/roundcube-rule-exclusions-plugin/9519153.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: Roundcube rule exclusions plsugin
+              User-Agent: Roundcube rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded; charset=UTF-8
             port: 80
@@ -32,7 +32,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: Roundcube rule exclusions plsugin
+              User-Agent: Roundcube rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80

--- a/tests/regression/roundcube-rule-exclusions-plugin/9519156.yaml
+++ b/tests/regression/roundcube-rule-exclusions-plugin/9519156.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: Roundcube rule exclusions plsugin
+              User-Agent: Roundcube rule exclusions plugin
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -23,4 +23,4 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: |
-              id "(?:921180|941101)"
+              id "921180"|id "941101"


### PR DESCRIPTION
Some tests had mistakes in them that prevented the correct matching of invalid rules, or content type headers not being added correctly.